### PR TITLE
make loading of original module work also for environments containing "argparse2tool"

### DIFF
--- a/argparse2tool/__init__.py
+++ b/argparse2tool/__init__.py
@@ -11,7 +11,7 @@ __version__ = '0.4.8'
 
 def load_argparse():
     ARGPARSE_NUMBER = 1
-    return load_conflicting_package('argparse', 'argparse2tool', ARGPARSE_NUMBER)
+    return load_conflicting_package('argparse', 'argparse2tool/dropins', ARGPARSE_NUMBER)
 
 
 def load_conflicting_package(name, not_name, module_number):

--- a/argparse2tool/__init__.py
+++ b/argparse2tool/__init__.py
@@ -14,6 +14,11 @@ def load_argparse():
     return load_conflicting_package('argparse', 'argparse2tool/dropins', ARGPARSE_NUMBER)
 
 
+def load_click():
+    CLICK_NUMBER = 5
+    return load_conflicting_package('click', 'argparse2tool/dropins', CLICK_NUMBER)
+
+
 def load_conflicting_package(name, not_name, module_number):
     """Load a conflicting package
     Some assumptions are made, namely that your package includes the "official"

--- a/argparse2tool/__init__.py
+++ b/argparse2tool/__init__.py
@@ -6,7 +6,7 @@ except Exception:
     pass
 
 
-__version__ = '0.4.8'
+__version__ = '0.4.9'
 
 
 def load_argparse():

--- a/argparse2tool/__init__.py
+++ b/argparse2tool/__init__.py
@@ -37,10 +37,9 @@ def load_conflicting_package(name, not_name, module_number):
     for path in sys.path:
         try:
             (f, pathname, desc) = imp.find_module(name, [path])
-            if not_name not in pathname and desc[2] == module_number:
-                imp.load_module(random_name, f, pathname, desc)
-                return sys.modules[random_name]
-        except Exception:
-            # Many sys.paths won't contain the module of interest
-            pass
+        except ImportError:
+            continue
+        if not_name not in pathname and desc[2] == module_number:
+            imp.load_module(random_name, f, pathname, desc)
+            return sys.modules[random_name]
     return None

--- a/argparse2tool/dropins/click/__init__.py
+++ b/argparse2tool/dropins/click/__init__.py
@@ -8,7 +8,7 @@ from argparse2tool import load_conflicting_package
 from argparse2tool.cmdline2cwl import Arg2CWLParser
 
 CLICK_NUMBER = 5
-click = load_conflicting_package('click', 'argparse2tool', CLICK_NUMBER)
+click = load_conflicting_package('click', 'argparse2tool/dropins', CLICK_NUMBER)
 __selfmodule__ = sys.modules[__name__]
 # This fetches a reference to ourselves
 

--- a/argparse2tool/dropins/click/__init__.py
+++ b/argparse2tool/dropins/click/__init__.py
@@ -4,11 +4,10 @@ import sys
 
 from click import click_cwl_translation as cct
 from argparse2tool.cmdline2cwl import cwl_tool as cwlt
-from argparse2tool import load_conflicting_package
+from argparse2tool import load_click
 from argparse2tool.cmdline2cwl import Arg2CWLParser
 
-CLICK_NUMBER = 5
-click = load_conflicting_package('click', 'argparse2tool/dropins', CLICK_NUMBER)
+click = load_click()
 __selfmodule__ = sys.modules[__name__]
 # This fetches a reference to ourselves
 

--- a/examples/example-click.cwl
+++ b/examples/example-click.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-# This tool description was generated automatically by argparse2tool ver. 0.4.8
+# This tool description was generated automatically by argparse2tool ver. 0.4.9
 # To generate again: $ example-click.py --generate_cwl_tool
 # Help: $ example --help_arg2cwl
 


### PR DESCRIPTION
See also https://github.com/bioconda/bioconda-recipes/pull/23347#issuecomment-665167219

Not sure if the 2nd commit (https://github.com/hexylena/argparse2tool/pull/69/commits/7047a1b4885f5e9fef01ab1fe6316ef39164f0fa) is a good idea. But seems to work.