### PR TITLE
Replace `imp` with `importlib`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             flake8 argparse2tool --ignore=E2,E3,E4,E5,W3,W505
             PYTHONPATH=$(argparse2tool) python examples/example.py --generate_galaxy_xml > tmp.xml
             xmldiff tmp.xml examples/example.xml
-            planemo lint --report_level all --fail_level error --xsd tmp.xml
+            planemo lint --report_level all --fail_level error tmp.xml
 
             # Galaxy tool generation for example with subparsers -- generating one large (invalid) tool
             echo '<root>' > tmp-sub.xml # wrap in extra level
@@ -43,9 +43,9 @@ jobs:
             PYTHONPATH=$(argparse2tool) python examples/example-sub.py --generate_galaxy_xml --command foo > tmp-sub-foo.xml
             PYTHONPATH=$(argparse2tool) python examples/example-sub.py --generate_galaxy_xml --command bar > tmp-sub-bar.xml
             xmldiff tmp-sub-foo.xml examples/example-sub-foo.xml
-            planemo lint --report_level all --fail_level error --xsd tmp-sub-foo.xml
+            planemo lint --report_level all --fail_level error tmp-sub-foo.xml
             xmldiff tmp-sub-bar.xml examples/example-sub-bar.xml
-            planemo lint --report_level all --fail_level error --xsd tmp-sub-bar.xml
+            planemo lint --report_level all --fail_level error tmp-sub-bar.xml
 
             PYTHONPATH=$(argparse2tool) python examples/example.py --generate_cwl_tool > tmp.cwl
             PYTHONPATH=$(argparse2tool) python examples/example-sub.py --generate_cwl_tool > tmp-sub.cwl

--- a/argparse2tool/__init__.py
+++ b/argparse2tool/__init__.py
@@ -1,22 +1,26 @@
 """Stub for argparse2tool"""
+
 import sys
+
 try:
     from builtins import range
 except Exception:
     pass
 
 
-__version__ = '0.4.9'
+__version__ = "0.4.9"
 
 
 def load_argparse():
     ARGPARSE_NUMBER = 1
-    return load_conflicting_package('argparse', 'argparse2tool/dropins', ARGPARSE_NUMBER)
+    return load_conflicting_package(
+        "argparse", "argparse2tool/dropins", ARGPARSE_NUMBER
+    )
 
 
 def load_click():
     CLICK_NUMBER = 5
-    return load_conflicting_package('click', 'argparse2tool/dropins', CLICK_NUMBER)
+    return load_conflicting_package("click", "argparse2tool/dropins", CLICK_NUMBER)
 
 
 def load_conflicting_package(name, not_name, module_number):
@@ -28,9 +32,11 @@ def load_conflicting_package(name, not_name, module_number):
 
      http://stackoverflow.com/a/6032023
     """
-    import imp
+    import importlib.util
+    import importlib.machinery
+
     for i in range(0, 100):
-        random_name = 'random_name_%d' % (i,)
+        random_name = f"random_name_{i}"
         if random_name not in sys.modules:
             break
         else:
@@ -41,10 +47,20 @@ def load_conflicting_package(name, not_name, module_number):
     # This will hold the correct sys.path for the REAL argparse
     for path in sys.path:
         try:
-            (f, pathname, desc) = imp.find_module(name, [path])
+            spec = importlib.machinery.PathFinder.find_spec(name, [path])
+            if spec is None or spec.origin is None:
+                continue
+
+            # Check if this is the module we want (avoiding the override)
+            if not_name not in spec.origin and isinstance(
+                spec.loader, importlib.machinery.SourceFileLoader
+            ):
+                spec.loader.name = random_name
+                spec.name = random_name
+                module = importlib.util.module_from_spec(spec)
+                sys.modules[random_name] = module
+                spec.loader.exec_module(module)
+                return sys.modules[random_name]
         except ImportError:
             continue
-        if not_name not in pathname and desc[2] == module_number:
-            imp.load_module(random_name, f, pathname, desc)
-            return sys.modules[random_name]
     return None

--- a/argparse2tool/check_path.py
+++ b/argparse2tool/check_path.py
@@ -4,16 +4,19 @@ click
 
 intended use: `PYTHONPATH=$(argparse2tool) python script.py ...`
 """
-import imp
+import importlib.util
 import os
 import sys
 
 
 def main():
-    (handle, pathname, desc) = imp.find_module('argparse2tool')
-    if desc[2] != 5:
+    spec = importlib.util.find_spec("argparse2tool")
+    if spec is None:
         sys.exit("could not find argparse2tool")
+
+    pathname = os.path.dirname(spec.origin)
     path = os.path.join(pathname, "dropins")
+
     if not os.path.exists(path):
         sys.exit("no dropins dir %s" % path)
     if not os.path.exists(os.path.join(path, "argparse")):
@@ -24,5 +27,5 @@ def main():
     print(path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
This replaces `imp` module with `importlib`, and makes argparse2tool compatible with python 3.12 and newer. The reason is that `imp` [module is deprecated](https://docs.python.org/3.11/library/imp.html) since python 3.4 and was removed in 3.12. 

I'm using this tool (and really like it so far!) in a cwl generator and would like to also support current python versions. Thanks!